### PR TITLE
fix(back): move error attribute formatting to Error() function

### DIFF
--- a/backend/log/attribute/error.go
+++ b/backend/log/attribute/error.go
@@ -1,9 +1,24 @@
 package attribute
 
-import "log/slog"
+import (
+	"log/slog"
+	"reflect"
+)
 
 const KeyError = "error"
 
-type ErrorValue struct{ Err error }
-
-func Error(err error) slog.Attr { return slog.Any(KeyError, &ErrorValue{Err: err}) }
+func Error(err error) slog.Attr {
+	if err == nil {
+		return slog.Attr{}
+	}
+	typErr := reflect.TypeOf(err)
+	attrs := make([]slog.Attr, 0, 3)
+	attrs = append(attrs,
+		slog.String("type", typErr.String()),
+		slog.String("msg", err.Error()),
+	)
+	if pkg := typErr.PkgPath(); pkg != "" {
+		attrs = append(attrs, slog.String("pkg", pkg))
+	}
+	return slog.GroupAttrs(KeyError, attrs...)
+}

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -17,7 +17,6 @@ func ProvideJSONLogger(out Output, level slog.Level, svcVersion o11y.ServiceVers
 		slog.NewJSONHandler(out, &slog.HandlerOptions{Level: level}),
 		injectOtelAttrs,
 		injectServiceVersion(svcVersion),
-		transformError,
 	)
 	return slog.New(handler)
 }

--- a/backend/log/middleware.go
+++ b/backend/log/middleware.go
@@ -2,10 +2,8 @@ package log
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
-	"careco/backend/log/attribute"
 	"careco/backend/o11y"
 
 	"go.opentelemetry.io/otel/trace"
@@ -31,27 +29,6 @@ func injectServiceVersion(svcVersion o11y.ServiceVersion) middleware {
 			return next.Handle(ctx, record)
 		})
 	}
-}
-
-func transformError(next handler) handler {
-	return handlerFunc(func(ctx context.Context, record slog.Record) error {
-		newRecord := slog.NewRecord(record.Time, record.Level, record.Message, record.PC)
-		for a := range record.Attrs {
-			if a.Key == attribute.KeyError {
-				if ev, ok := a.Value.Any().(*attribute.ErrorValue); ok {
-					ga := slog.GroupAttrs(
-						attribute.KeyError,
-						slog.String("type", fmt.Sprintf("%T", ev.Err)),
-						slog.String("msg", ev.Err.Error()),
-					)
-					newRecord.AddAttrs(ga)
-				}
-			} else {
-				newRecord.AddAttrs(a)
-			}
-		}
-		return next.Handle(ctx, newRecord)
-	})
 }
 
 type handler interface {


### PR DESCRIPTION
Previously, error type extraction and formatting was handled by the transformError middleware. This meant that environments without the middleware (e.g., tests using slog.Default()) wouldn't benefit from structured error logging.

By moving this logic into attribute.Error(), any code using this function gets consistent error attribute structure regardless of logger configuration, with minimal overhead when no error is present.